### PR TITLE
Allow to pass totalizer object to use its name as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for passing the whole totalizer object (with name and id).
+
+### Changed
+
+- Translate totalizer if it's id is one of a specific set of known totalizers.
+- Use the totalizer name if the id is not in the known totalizers enum.
+
 ## [2.0.0] - 2019-02-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -25,11 +25,31 @@ import TranslateTotalizer from 'vtex.totalizer-translator/TranslateTotalizer'
 
 <TranslateTotalizer id="Foo Custom" />
 // Foo Custom
+
+const totalizerObject = {
+  id: 'CustomTax',
+  name: 'COFINS-RETIDO',
+  value: 29.97,
+}
+
+<TranslateTotalizer totalizer={totalizerObject}/>
+// COFINS-RETIDO
 ```
 
 ### Params
 
 - **id** | Type `string` | Id of the totalizer to be translated
+- **totalizer** | Type `TotalizerShape` | The totalizer object
+
+**TotalizerShape**:
+
+```ts
+{
+  id: string
+  name: string
+  value: number
+}
+```
 
 ### Returns
 

--- a/manifest.json
+++ b/manifest.json
@@ -17,5 +17,6 @@
   "settingsSchema": {},
   "scripts": {
     "postreleasy": "vtex publish --verbose"
-  }
+  },
+  "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -1,7 +1,7 @@
 {
-  "totalizers.Discounts": "Descomptes",
-  "totalizers.Items": "Subtotal",
-  "totalizers.Shipping": "Cost de l'enviament",
-  "totalizers.Tax": "Impostos",
-  "totalizers.Interest": "Interès"
+  "store/totalizers.Discounts": "Descomptes",
+  "store/totalizers.Items": "Subtotal",
+  "store/totalizers.Shipping": "Cost de l'enviament",
+  "store/totalizers.Tax": "Impostos",
+  "store/totalizers.Interest": "Interès"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,7 +1,7 @@
 {
-  "totalizers.Discounts": "Discount",
-  "totalizers.Items": "Subtotal",
-  "totalizers.Shipping": "Shipping",
-  "totalizers.Tax": "Taxes",
-  "totalizers.Interest": "Interest"
+  "store/totalizers.Discounts": "Discount",
+  "store/totalizers.Items": "Subtotal",
+  "store/totalizers.Shipping": "Shipping",
+  "store/totalizers.Tax": "Taxes",
+  "store/totalizers.Interest": "Interest"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,7 +1,7 @@
 {
-  "totalizers.Discounts": "Discount",
-  "totalizers.Items": "Subtotal",
-  "totalizers.Shipping": "Shipping",
-  "totalizers.Tax": "Taxes",
-  "totalizers.Interest": "Interest"
+  "store/totalizers.Discounts": "Discount",
+  "store/totalizers.Items": "Subtotal",
+  "store/totalizers.Shipping": "Shipping",
+  "store/totalizers.Tax": "Taxes",
+  "store/totalizers.Interest": "Interest"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,7 +1,7 @@
 {
-  "totalizers.Discounts": "Descuentos",
-  "totalizers.Items": "Subtotal",
-  "totalizers.Shipping": "Costo del envío",
-  "totalizers.Tax": "Impuestos",
-  "totalizers.Interest": "Interés"
+  "store/totalizers.Discounts": "Descuentos",
+  "store/totalizers.Items": "Subtotal",
+  "store/totalizers.Shipping": "Costo del envío",
+  "store/totalizers.Tax": "Impuestos",
+  "store/totalizers.Interest": "Interés"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,7 +1,7 @@
 {
-  "totalizers.Discounts": "Rabais",
-  "totalizers.Items": "Sous-total",
-  "totalizers.Shipping": "Expédition",
-  "totalizers.Tax": "Taxes",
-  "totalizers.Interest": "Intérêt"
+  "store/totalizers.Discounts": "Rabais",
+  "store/totalizers.Items": "Sous-total",
+  "store/totalizers.Shipping": "Expédition",
+  "store/totalizers.Tax": "Taxes",
+  "store/totalizers.Interest": "Intérêt"
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,7 +1,7 @@
 {
-  "totalizers.Discounts": "할인",
-  "totalizers.Items": "소계",
-  "totalizers.Shipping": "배송",
-  "totalizers.Tax": "세금",
-  "totalizers.Interest": "이자"
+  "store/totalizers.Discounts": "할인",
+  "store/totalizers.Items": "소계",
+  "store/totalizers.Shipping": "배송",
+  "store/totalizers.Tax": "세금",
+  "store/totalizers.Interest": "이자"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,7 +1,7 @@
 {
-  "totalizers.Discounts": "Descontos",
-  "totalizers.Items": "Subtotal",
-  "totalizers.Shipping": "Entrega",
-  "totalizers.Tax": "Impostos",
-  "totalizers.Interest": "Juros"
+  "store/totalizers.Discounts": "Descontos",
+  "store/totalizers.Items": "Subtotal",
+  "store/totalizers.Shipping": "Entrega",
+  "store/totalizers.Tax": "Impostos",
+  "store/totalizers.Interest": "Juros"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -1,7 +1,7 @@
 {
-  "totalizers.Discounts": "Discount",
-  "totalizers.Items": "Subtotal",
-  "totalizers.Shipping": "Transport",
-  "totalizers.Tax": "TVA",
-  "totalizers.Interest": "Dobândă"
+  "store/totalizers.Discounts": "Discount",
+  "store/totalizers.Items": "Subtotal",
+  "store/totalizers.Shipping": "Transport",
+  "store/totalizers.Tax": "TVA",
+  "store/totalizers.Interest": "Dobândă"
 }

--- a/react/TranslateTotalizer.js
+++ b/react/TranslateTotalizer.js
@@ -1,21 +1,50 @@
-import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
-import { injectIntl, intlShape } from 'react-intl'
+import { injectIntl, intlShape, defineMessages } from 'react-intl'
 
-const TranslateTotal = ({ intl, id }) => {
-  if (!id) return ''
+export const knownTotalizers = defineMessages({
+  Discounts: {
+    id: 'store/totalizers.Discounts',
+    defaultMessage: 'Discounts',
+  },
+  Items: {
+    id: 'store/totalizers.Items',
+    defaultMessage: 'Items',
+  },
+  Shipping: {
+    id: 'store/totalizers.Shipping',
+    defaultMessage: 'Shipping',
+  },
+  Tax: {
+    id: 'store/totalizers.Tax',
+    defaultMessage: 'Tax',
+  },
+  Interest: {
+    id: 'store/totalizers.Interest',
+    defaultMessage: 'Interest',
+  },
+})
 
-  const text = intl.formatMessage({
-    id: `totalizers.${id}`,
-    defaultMessage: id,
-  })
+const TranslateTotal = ({ intl, id, totalizer }) => {
+  if (totalizer && totalizer.id) id = totalizer.id
 
-  return <Fragment>{text}</Fragment>
+  // if the totalizer is known, translate it
+  if (id in knownTotalizers) return intl.formatMessage(knownTotalizers[id])
+
+  // id is unknown and there's no totalizer object, render the id or an empty string
+  if (!totalizer) return id || ''
+
+  // totalizer exists, render its name or its id
+  return totalizer.name || id
 }
 
 TranslateTotal.propTypes = {
   intl: intlShape,
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string,
+  totalizer: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    value: PropTypes.number,
+  }),
 }
 
 export default injectIntl(TranslateTotal)

--- a/react/TranslateTotalizer.test.js
+++ b/react/TranslateTotalizer.test.js
@@ -2,6 +2,28 @@ import React from 'react'
 import TranslateTotalizer from './TranslateTotalizer'
 import { renderWithIntl, cleanup } from '../test-utils' // eslint-disable-line import/named
 
+const TotalizersMock = {
+  NoID: {
+    name: 'Mock Tax',
+    value: 10,
+  },
+  NoName: {
+    id: 'CustomTax',
+    name: '',
+    value: 10.24,
+  },
+  Interest: {
+    id: 'Interest',
+    name: 'Total de juros',
+    value: 0,
+  },
+  CustomTax: {
+    id: 'CustomTax',
+    name: 'COFINS-RETIDO',
+    value: 29.97,
+  },
+}
+
 describe('TranslateTotalizer', () => {
   afterEach(cleanup)
 
@@ -9,7 +31,6 @@ describe('TranslateTotalizer', () => {
     const { getByText } = renderWithIntl(<TranslateTotalizer id="Discounts" />)
 
     const text = getByText('Discount')
-
     expect(text).toBeDefined()
   })
 
@@ -17,7 +38,42 @@ describe('TranslateTotalizer', () => {
     const { getByText } = renderWithIntl(<TranslateTotalizer id="Foo" />)
 
     const text = getByText('Foo')
+    expect(text).toBeDefined()
+  })
 
+  it('should allow to pass a totalizer object and translate by its id', () => {
+    const { getByText } = renderWithIntl(
+      <TranslateTotalizer totalizer={TotalizersMock.Interest} />
+    )
+
+    const text = getByText('Interest')
+    expect(text).toBeDefined()
+  })
+
+  it('should render name if id unknown', () => {
+    const { getByText } = renderWithIntl(
+      <TranslateTotalizer totalizer={TotalizersMock.CustomTax} />
+    )
+
+    const text = getByText('COFINS-RETIDO')
+    expect(text).toBeDefined()
+  })
+
+  it('should render id as a fallback if no name is present', () => {
+    const { getByText } = renderWithIntl(
+      <TranslateTotalizer totalizer={TotalizersMock.NoName} />
+    )
+
+    const text = getByText('CustomTax')
+    expect(text).toBeDefined()
+  })
+
+  it('should render name as fallback if no id is present', () => {
+    const { getByText } = renderWithIntl(
+      <TranslateTotalizer totalizer={TotalizersMock.NoID} />
+    )
+
+    const text = getByText('Mock Tax')
     expect(text).toBeDefined()
   })
 })


### PR DESCRIPTION
Sometimes, the totalizer has a `name` that should be shown instead of its `id`. This PR aims to be backward compatible and allow to pass a totalizer object with `id` and `name`.